### PR TITLE
Simplify Monodomain initializer

### DIFF
--- a/src/cbcbeatx/__init__.py
+++ b/src/cbcbeatx/__init__.py
@@ -1,5 +1,6 @@
 """Top-level package for cbcbeatx."""
 from .monodomainsolver import MonodomainSolver
+from .markerwisefield import rhs_with_markerwise_field, Markerwise
 from importlib.metadata import metadata
 
 meta = metadata("cbcbeatx")
@@ -9,4 +10,4 @@ __license__ = meta["License"]
 __email__ = meta["Author-email"]
 __program_name__ = meta["Name"]
 
-__all__ = ["MonodomainSolver"]
+__all__ = ["MonodomainSolver", "rhs_with_markerwise_field", "Markerwise"]

--- a/tests/test_monodomain.py
+++ b/tests/test_monodomain.py
@@ -20,7 +20,7 @@ class TestMonodomainSolver():
         self.M_i = 1.0
 
         self.t0 = 0.0
-        self.dt = 0.1
+        self.dt = 0.01
 
     @pytest.mark.fast
     def test_solve(self):
@@ -97,13 +97,13 @@ class TestMonodomainSolver():
 
 @pytest.mark.parametrize("theta", [0.5, 1.])
 @pytest.mark.parametrize("degree", [1, 2])
-def test_manufactured_solution(theta, degree):
+def test_manufactured_solution(theta: float, degree: int):
     """
     Test Monodomain solver against a manufactured solution
 
     Args:
-        theta (_type_): Time discretization parameter
-        degree (_type_): Degree of membrane potential funciton space
+        theta (float): Time discretization parameter
+        degree (int): Degree of membrane potential function space
     """
     num_refs = 3
     dt = 1e-3


### PR DESCRIPTION
# Monodomainsolver
- Split initializer into sub-modules
- Have a default parameter dictionary that is accessible from `MonodomainSolver`

# Other updates
- Proper documentation of` markerwisefield.py`
- Set form and jit options for preconditioner form as well