### PR TITLE
Remove __slots__ from monodomainsolver class

### DIFF
--- a/src/cbcbeatx/monodomainsolver.py
+++ b/src/cbcbeatx/monodomainsolver.py
@@ -113,7 +113,6 @@ class MonodomainSolver:
     _prec_matrix: PETSc.Mat  # type: ignore
     _custom_prec: bool
 
-    __slots__ = tuple(__annotations__)
 
     def __init__(
         self,


### PR DESCRIPTION
Removed __slots__ declaration from the class.